### PR TITLE
Add tests: TravisCI and tox configurations for Python 2.7 and 3.6 and Django 1.8 and 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+cache:
+  pip: true
+
+language:
+  python
+
+python:
+  - "2.7"
+  - "3.6"
+
+env:
+  - DJANGO=18
+  - DJANGO=110
+
+install:
+  - export TOXENV=py${TRAVIS_PYTHON_VERSION//./}-django${DJANGO}
+
+script:
+  - tox -e ${TOXENV}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ language:
 
 python:
   - "2.7"
+  - "3.4"
+  - "3.5"
   - "3.6"
 
 env:
@@ -13,6 +15,7 @@ env:
   - DJANGO=110
 
 install:
+  - pip install tox
   - export TOXENV=py${TRAVIS_PYTHON_VERSION//./}-django${DJANGO}
 
 script:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Django Messages Extends
 ==========================
 
+[![Build Status](https://travis-ci.org/mpasternak/django-messages-extends.svg?branch=master)](https://travis-ci.org/mpasternak/django-messages-extends)
+
 A Django app for extends Django's [messages framework](http://docs.djangoproject
 .com/en/dev/ref/contrib/messages/) (`django.contrib.messages`). framework by adding "sticky"  and
  "persistent" backend message storages.  This also supports the notion of sending

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Django Messages Extends
 ==========================
 
+
 [![Build Status](https://travis-ci.org/mpasternak/django-messages-extends.svg?branch=master)](https://travis-ci.org/mpasternak/django-messages-extends)
+
 
 A Django app for extends Django's [messages framework](http://docs.djangoproject
 .com/en/dev/ref/contrib/messages/) (`django.contrib.messages`). framework by adding "sticky"  and

--- a/test_urls.py
+++ b/test_urls.py
@@ -1,18 +1,11 @@
-from django.conf.urls import patterns, include, url
+import django
 
-# Uncomment the next two lines to enable the admin:
-# from django.contrib import admin
-# admin.autodiscover()
+if django.VERSION >= (1,10):
+    from django.conf.urls import include, url
+    patterns = lambda _ignore, x: list([x,])
+else:
+    from django.conf.urls import patterns, include, url
 
 urlpatterns = patterns('',
-    # Examples:
-    # url(r'^$', 'temp.views.home', name='home'),
-    # url(r'^temp/', include('temp.foo.urls')),
-
-    # Uncomment the admin/doc line below to enable admin documentation:
-    # url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
-
-    # Uncomment the next line to enable the admin:
-    # url(r'^admin/', include(admin.site.urls)),
     url(r'^messages/', include('messages_extends.urls', namespace='messages')),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py{27,36}-django{18,110}
+
+[testenv]
+commands = python setup.py test
+deps = 
+     django18: django>=1.8, <1.9
+     django110: django>=1.10, <1.11

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,36}-django{18,110}
+envlist = py{27,34,35,36}-django{18,110}
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
Hey @AliLozano , are you there? 

I'm using django-messages-extends. And I actually plan adding a thin layer (as an external module) to support live-messages like in my project called django-monitio (deprecated). So I guess, like, to move forward, I need tests. And a PyPI release. 

Are you still interested in maintaining dme? If not, feel free to give me privileges as I can maintain this package for a while. Thanks. 