### PR TITLE
added __hash__ function to Message so Django can call .delete()

### DIFF
--- a/messages_extends/models.py
+++ b/messages_extends/models.py
@@ -34,9 +34,11 @@ class Message(models.Model):
         return isinstance(other, Message) and self.level == other.level and\
                self.message == other.message
 
+    def __hash__(self):
+        return hash((self.level, self.message))
+
     def __str__(self):
         return force_text(self.message)
-
 
     def _prepare_message(self):
         """

--- a/messages_extends/tests.py
+++ b/messages_extends/tests.py
@@ -124,3 +124,9 @@ class MessagesTests(TestCase):
         ps._message_queryset = _patched_queryset
         ps._get()
         self.assertEquals(no_called[0], 1)
+
+    def test_delete(self):
+        messages.add_message(self.client, WARNING_PERSISTENT, "Warning Test")
+        self.assertEquals(Messages.objects.count(), 1)
+        messages.delete()
+        self.assertEquals(Messages.objects.count(), 0)

--- a/messages_extends/tests.py
+++ b/messages_extends/tests.py
@@ -126,7 +126,9 @@ class MessagesTests(TestCase):
         self.assertEquals(no_called[0], 1)
 
     def test_delete(self):
+        user = self._get_user()
+        self.client.login(username=user.username, password='password')
         messages.add_message(self.client, WARNING_PERSISTENT, "Warning Test")
-        self.assertEquals(Messages.objects.count(), 1)
-        messages.delete()
-        self.assertEquals(Messages.objects.count(), 0)
+        self.assertEquals(Message.objects.count(), 1)
+        Message.objects.filter(user=user).first().delete()
+        self.assertEquals(Message.objects.count(), 0)


### PR DESCRIPTION
Followed the advice here from Python docs to create hash function. Django uses sets to compare objects in its `model.delete()` method, which requires hashable models. When you add an `__eq__` function without a `__hash__` function, Python does not consider the object hashable. The PR adds a hash function that takes into account both properties used in the pre-existing `__eq__` function: `level` and `message`.

https://docs.python.org/3/reference/datamodel.html#object.__hash__