### PR TITLE
Making auto-created primary key explicit

### DIFF
--- a/messages_extends/models.py
+++ b/messages_extends/models.py
@@ -10,6 +10,7 @@ from django.conf import settings
 LEVEL_TAGS = utils.get_level_tags()
 
 class Message(models.Model):
+    id = models.AutoField(primary_key=True)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True,
                              on_delete=models.CASCADE)
     message = models.TextField()

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,4 @@ envlist = py{35,36,37,38}-django{22,30}
 commands = python setup.py test
 deps = 
      django22: django>=2.2, <2.3
-     django30: django>=3.0, <3.1
+     django30: django>=3.0, <3.2


### PR DESCRIPTION
Django 3.2 introduces this in anticipation of changing the defaults.

https://docs.djangoproject.com/en/3.2/releases/3.2/#whats-new-3-2