### PR TITLE
Making auto-created primary key explicit

### DIFF
--- a/messages_extends/models.py
+++ b/messages_extends/models.py
@@ -10,6 +10,7 @@ from django.conf import settings
 LEVEL_TAGS = utils.get_level_tags()
 
 class Message(models.Model):
+    id = models.AutoField(primary_key=True)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True,
                              on_delete=models.CASCADE)
     message = models.TextField()


### PR DESCRIPTION
Django 3.2 introduces this in anticipation of changing the defaults.

https://docs.djangoproject.com/en/3.2/releases/3.2/#whats-new-3-2

2023-01-19 Update. Removed tox.ini conflict